### PR TITLE
Stop all AnimationActions on unmount/mixer change

### DIFF
--- a/src/core/useAnimations.tsx
+++ b/src/core/useAnimations.tsx
@@ -49,5 +49,12 @@ export function useAnimations<T extends AnimationClip>(
       })
     }
   }, [clips])
+
+  React.useEffect(() => {
+    return () => {
+      mixer.stopAllAction()
+    }
+  }, [mixer])
+
   return api
 }


### PR DESCRIPTION
### Why

resolves #1175 

### What

Added useEffect to stop actions when the mixer changes. 
 
### Checklist

- [ x ] Documentation updated
- [ x ] Storybook entry added
- [ x ] Ready to be merged

### Comments 

Not sure, if this is ready to be merged tbh. but it fixes *my* bug at least... 

